### PR TITLE
 Fix mongo aggregate mocking 

### DIFF
--- a/deuce/tests/db_mocking/mongodb_mocking.py
+++ b/deuce/tests/db_mocking/mongodb_mocking.py
@@ -11,24 +11,33 @@ from mongomock.collection import Collection
 
 # Mongomock does not have aggregate impl.
 # Patch a quick impl.
-def patch_aggregate(self, list):
-    if self._aggregate_calling_cnt is 0:
-        retval = dict()
-        retval['result'] = [{'blocks': [{'blockid': 'full mocking'}]}]
-        self._aggregate_calling_cnt += 1
-        return retval
-    else:
+def patch_aggregate(self, arglist):
+    num_blocks = 0
+    for item in arglist:
+        if any(key == '$limit' for key in item):
+            num_blocks = item['$limit']
+
+    if num_blocks == -1:
         retval = dict()
         retval['result'] = [{'blocks': []}]
-        self._aggregate_calling_cnt += 1
         return retval
+
+    if num_blocks != 4:
+        num_blocks = 40
+
+    retval = dict()
+
+    blocks = [{'blockid': 'block_{0}'.format(x),
+        'offset': x * 333} for x in range(0, num_blocks)]
+    retval['result'] = [{'blocks': blocks}]
+
+    return retval
 
 old_init = Collection.__init__
 
 
 def new_init(self, db, name):
     old_init(self, db, name)
-    self._aggregate_calling_cnt = 0
 
 Collection.aggregate = patch_aggregate
 Collection.__init__ = new_init

--- a/deuce/tests/test_sqlite_storage_driver.py
+++ b/deuce/tests/test_sqlite_storage_driver.py
@@ -152,7 +152,6 @@ class SqliteStorageDriverTest(FunctionalTest):
         retgen = \
             driver.create_file_block_generator(
                 project_id, vault_id, file_id, offset, limit)
-
         fetched_blocks = list(retgen)
 
         # The driver actually returns limit+1 so that any
@@ -171,20 +170,26 @@ class SqliteStorageDriverTest(FunctionalTest):
 
         # Now create a generator of the files. The output
         # should be in the same order as block_ids
+        # With default marker
         gen = driver.create_block_generator(project_id, vault_id)
-
         fetched_blocks = list(gen)
-
+        assert len(fetched_blocks) == num_blocks
+        # With given marker
+        gen = driver.create_block_generator(project_id, vault_id, marker=0)
+        fetched_blocks = list(gen)
         assert len(fetched_blocks) == num_blocks
 
         # Now try file_block_generator with no limit
         retgen = \
             driver.create_file_block_generator(
                 project_id, vault_id, file_id, offset=None, limit=None)
-
         output = list(retgen)
-
         self.assertEqual(output, list(zip(block_ids, offsets)))
+
+        # With a wrong limit
+        retgen = \
+            driver.create_file_block_generator(
+                project_id, vault_id, file_id, offset=None, limit=-1)
 
     def test_file_generator(self):
 


### PR DESCRIPTION
1. Add more tests cases.
2. Fix mongo aggregate mocking for more query results.
